### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ particularly useful if you're hosting several services on the same machine and
 want to access them by name instead of needing to remember port numbers.
 
 ## Installation
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/tailservice
+```
+
+Or install with `go`:
 
 ```bash
 go install github.com/sierrasoftworks/tailservice@latest


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/tailservice

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
